### PR TITLE
avoid swapping width and height for desktop

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -7,7 +7,7 @@ void main() {
 }
 
 class MyApp extends StatelessWidget {
-  const MyApp();
+  const MyApp({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {

--- a/example/lib/screens/first_page_screen_without_sizer.dart
+++ b/example/lib/screens/first_page_screen_without_sizer.dart
@@ -4,7 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 
 class FirstPageScreenWithoutSizer extends StatefulWidget {
-  FirstPageScreenWithoutSizer({
+  const FirstPageScreenWithoutSizer({
     Key? key,
   }) : super(key: key);
 

--- a/lib/util.dart
+++ b/lib/util.dart
@@ -30,7 +30,8 @@ class SizerUtil {
     orientation = currentOrientation;
 
     // Sets screen width and height
-    if (orientation == Orientation.portrait) {
+    if (orientation == Orientation.portrait ||
+        !(Platform.isAndroid || Platform.isIOS)) {
       width = boxConstraints.maxWidth;
       height = boxConstraints.maxHeight;
     } else {
@@ -48,8 +49,7 @@ class SizerUtil {
     if (kIsWeb) {
       deviceType = DeviceType.web;
     } else if (Platform.isAndroid || Platform.isIOS) {
-      if ((orientation == Orientation.portrait && width < 600) ||
-          (orientation == Orientation.landscape && height < 600)) {
+      if (width < 600) {
         deviceType = DeviceType.mobile;
       } else {
         deviceType = DeviceType.tablet;


### PR DESCRIPTION
For desktops, width and height should not be swapped because, resizing the window is not equivalent to rotating the screen. (in web to)